### PR TITLE
python-semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,31 +11,7 @@ on:
       - published
 
 jobs:
-  dist:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: hynek/build-and-inspect-python-package@v1
-
-  publish:
-    needs: [dist]
-    environment: pypi
-    permissions:
-      id-token: write
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
-
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
-
-      - uses: pypa/gh-action-pypi-publish@release/v1
-
+  # job to determine appropriate version number, update changelog, and create a release commit
   # release:
   #   runs-on: ubuntu-latest
   #   concurrency: release
@@ -52,3 +28,30 @@ jobs:
   #       uses: python-semantic-release/python-semantic-release@master
   #       with:
   #         github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # job to build and inspect the package
+  dist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: hynek/build-and-inspect-python-package@v1
+
+  # job to publish the new version to pypi
+  publish:
+    needs: [dist]
+    environment: pypi
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import importlib.metadata
+import invert4geom
 
 project = "invert4geom"
 copyright = "2023, Matt Tankersley"
 author = "Matt Tankersley"
-version = release = importlib.metadata.version("invert4geom")
+version = release = invert4geom.__version__
 extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm[toml]>=8"]
+requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -27,7 +27,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 readme = "README.md"
-dynamic = ["version"]
+version = "0.1.0"
 
 dependencies = [
   "numpy",
@@ -69,7 +69,7 @@ dev = [
   "nox",
   "pre-commit",
   "pylint",
-  "python-semantic-release",
+  "python-semantic-release >=8",
 ]
 docs = [
   "sphinx>=4.0",
@@ -87,9 +87,6 @@ Documentation = "https://invert4geom.readthedocs.io/"
 "Bug Tracker" = "https://github.com/mdtanker/invert4geom/issues"
 Discussions = "https://github.com/mdtanker/invert4geom/discussions"
 Changelog = "https://invert4geom.readthedocs.io/en/latest/changelog.html"
-
-[tool.setuptools_scm]
-write_to = "src/invert4geom/_version.py"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -210,5 +207,11 @@ messages_control.disable = [
 ]
 
 [tool.semantic_release]
-version_variable = "pyproject.toml:version"
+version_variables = ["src/invert4geom/__init__.py:__version__"]
+version_toml = ["pyproject.toml:project.version"]
 major_on_zero = false
+# build_command = "pip install poetry && poetry build"
+# build_command = """
+#     python -m pip install build~=0.10.0
+#     python -m build .
+# """

--- a/src/invert4geom/__init__.py
+++ b/src/invert4geom/__init__.py
@@ -8,6 +8,4 @@ contrast.
 
 from __future__ import annotations
 
-from ._version import version as __version__
-
-__all__ = ("__version__",)
+__version__ = "0.1.0"


### PR DESCRIPTION
Changes dynamic version to a manually typed version 0.1.0, and tells python-semanitc-release where this version is specified. Removes setuptools_scm. Configures semanitic-release.